### PR TITLE
Add custom gateway logic to VirtualService creation.

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -85,18 +85,24 @@ const (
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
 
-	// CustomGatewayAnnotationKey is the annotation for specifing the Gateway the VirtualService
-	// should use. This will append to the list of Gateways that Knative creates. For example,
+	// CustomExternalIPGatewayAnnotationKey is the annotation for specifing the Gateway a 
+	// VirtualService should list for external Ingress. This will append to the list of
+	// Gateways that Knative creates. The Gateway name format must be of either 
+	// {namespace}/{gateway-name} or {gateway-name}. For example,
 	//
-	//    networking.knative.dev/customGateway: default/some-gateway
-	//
-	// The Gateway name format must be of either {namespace}/{gateway-name} or {gateway-name},
-	// where the latter expects the Gateway to be in the same namespace as the service.
-	// As this is a user-created custom Gateway, users are responsible for maintaining the resource.
-	// This means that Knative will NOT be responsible for creating, reconciling, or deleting
-	// this Gateway. Knative will just append this to the list of Gateways where the VirtualService 
-	// rule should be applied to.
-	CustomGatewayAnnotationKey = "networking.knative.dev/customGateway"
+	//    networking.knative.dev/customGateway: some-namespace/some-gateway
+	// 
+	// Gateway name without a namespace will expect it to be in the same namespace 
+	// as the service. As a user-created custom Gateway, users are responsible for 
+	// maintaining the Gateway resource. This means that Knative will NOT be responsible 
+	// for creating, reconciling, or deleting this Gateway. Knative will just append this
+	// to the list of Gateways where the VirtualService rule should be applied to.
+	CustomExternalIPGatewayAnnotationKey = "networking.knative.dev/customExternalIPGatewayName"
+
+	// CustomClusterLocalGatewayAnnotationKey is the annotation for specifing the Gateway a 
+	// VirtualService should list for internal Ingress. Please refer to the description above
+	// for CustomExternalIPGatewayAnnotationKey for more detail.
+	CustomClusterLocalGatewayAnnotationKey = "networking.knative.dev/customClusterLocalGatewayName"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -84,6 +84,19 @@ const (
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.
 	WildcardCertDomainLabelKey = "networking.knative.dev/wildcardDomain"
+
+	// CustomGatewayAnnotationKey is the annotation for specifing the Gateway the VirtualService
+	// should use. This will append to the list of Gateways that Knative creates. For example,
+	//
+	//    networking.knative.dev/customGateway: default/some-gateway
+	//
+	// The Gateway name format must be of either {namespace}/{gateway-name} or {gateway-name},
+	// where the latter expects the Gateway to be in the same namespace as the service.
+	// As this is a user-created custom Gateway, users are responsible for maintaining the resource.
+	// This means that Knative will NOT be responsible for creating, reconciling, or deleting
+	// this Gateway. Knative will just append this to the list of Gateways where the VirtualService 
+	// rule should be applied to.
+	CustomGatewayAnnotationKey = "networking.knative.dev/customGateway"
 )
 
 // ServiceType is the enumeration type for the Kubernetes services

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"reflect"
 
 	"knative.dev/pkg/apis/istio/v1alpha3"
@@ -290,6 +291,9 @@ func (r *BaseIngressReconciler) reconcileIngress(ctx context.Context, ra Reconci
 	logger.Infof("Reconciling ingress: %#v", ia)
 
 	gatewayNames := qualifiedGatewayNamesFromContext(ctx)
+	// Fetch user-defined custom gateways to add if specified.
+	gatewayNames = addCustomGatewaysToGatewayList(ia, gatewayNames)
+
 	vses, err := resources.MakeVirtualServices(ia, gatewayNames)
 	if err != nil {
 		return err
@@ -603,4 +607,28 @@ func getLBStatus(gatewayServiceURL string) []v1alpha1.LoadBalancerIngressStatus 
 
 func enableReconcileGateway(ctx context.Context) bool {
 	return config.FromContext(ctx).Network.AutoTLS || config.FromContext(ctx).Istio.ReconcileExternalGateway
+}
+
+func addCustomGatewaysToGatewayList(ia v1alpha1.IngressAccessor, gatewayList map[v1alpha1.IngressVisibility]sets.String) map[v1alpha1.IngressVisibility]sets.String {
+	externalIPCustomGateway := ia.GetAnnotations()[networking.CustomExternalIPGatewayAnnotationKey]
+	if externalIPCustomGateway != "" {
+		externalIPCustomGateway = getQualifiedName(ia, externalIPCustomGateway)
+		gatewayList[v1alpha1.IngressVisibilityExternalIP].Insert(externalIPCustomGateway)
+	}
+
+	clusterLocalCustomGateway := ia.GetAnnotations()[networking.CustomClusterLocalGatewayAnnotationKey]
+	if clusterLocalCustomGateway != "" {
+		clusterLocalCustomGateway = getQualifiedName(ia, clusterLocalCustomGateway)
+		gatewayList[v1alpha1.IngressVisibilityClusterLocal].Insert(clusterLocalCustomGateway)
+	}
+	return gatewayList
+}
+
+// Qualified name format of the custom gateway is either {namespace}/{gateway-name} or {gateway-name}.
+// If namespace is not specified, it will default to the service namespace.		
+func getQualifiedName(ia v1alpha1.IngressAccessor, gatewayName string) string {
+	if !strings.Contains(gatewayName, "/") {
+		gatewayName = ia.GetNamespace() + "/" + gatewayName
+	}
+	return gatewayName
 }

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -113,14 +113,40 @@ func MakeMeshVirtualService(ia v1alpha1.IngressAccessor) *v1alpha3.VirtualServic
 func MakeVirtualServices(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.IngressVisibility]sets.String) ([]*v1alpha3.VirtualService, error) {
 	vss := []*v1alpha3.VirtualService{MakeMeshVirtualService(ia)}
 
-	requiredGatewayCount := 0
-	if len(getPublicIngressRules(ia)) > 0 {
-		requiredGatewayCount += gateways[v1alpha1.IngressVisibilityExternalIP].Len()
-	}
+	// !!!!!!-------------------------WARNING-------------------------!!!!!!
+	// THIS IS A TEMPORARY OVERRIDE TO SUPPORT CUSTOM GATEWAYS PER SERVICE.
+	// We are overriding the Knative logic of populating gateways in its virtual service. This is until Knative
+	// supports splitting gateways per service as tracked by this PR (https://github.com/knative/serving/pull/4909).
+	// Contact Chris Sherry(chsherry), Joon Lee(joonlee), Rakesh Kelkar(rakelkar) for any related questions.
+	//
+	// ------ Overriding Changes
+	// Virtual services will reference a single custom gateway with the name format of
+	// {service-name}-gateway. This expects the gateway to be deployed at the namespace of the service.
+	// Thus, the QualifiedName of the gateway is {namespace}/{service-name}-gateway.
+	// The custom gateway CRD is created by our servicegateway controller not Knative. For details on controller,
+	// refer to https://msdata.visualstudio.com/Vienna/_git/mir-instances?path=%2FREADME.md&version=GBmaster
+	// !!!!!!---------------------------------------------------------!!!!!!
 
-	if len(getClusterLocalIngressRules(ia)) > 0 {
-		requiredGatewayCount += gateways[v1alpha1.IngressVisibilityClusterLocal].Len()
-	}
+	//// Original Knative logic commented out
+	// requiredGatewayCount := 0
+	// if len(getPublicIngressRules(ia)) > 0 {
+	// 	requiredGatewayCount += gateways[v1alpha1.IngressVisibilityExternalIP].Len()
+	// }
+
+	// if len(getClusterLocalIngressRules(ia)) > 0 {
+	// 	requiredGatewayCount += gateways[v1alpha1.IngressVisibilityClusterLocal].Len()
+	// }
+
+	//// Overriding custom logic
+	requiredGatewayCount := 1
+	customPublicGateways := sets.NewString()
+	// Gateway qualified name is {namespace}/{service-name}-gateway
+	customGatewayQualifiedName := VirtualServiceNamespace(ia) + "/" + names.IngressVirtualService(ia) + "-gateway"
+	customPublicGateways.Insert(customGatewayQualifiedName)
+	// Override the Knative deafult public gateway to the custom gateway
+	gateways[v1alpha1.IngressVisibilityExternalIP] = customPublicGateways
+	// Delete the Knative deafult private gateway
+	delete(gateways, v1alpha1.IngressVisibilityClusterLocal)
 
 	if requiredGatewayCount > 0 {
 		vss = append(vss, MakeIngressVirtualService(ia, gateways))

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -122,19 +122,6 @@ func MakeVirtualServices(ia v1alpha1.IngressAccessor, gateways map[v1alpha1.Ingr
 		requiredGatewayCount += gateways[v1alpha1.IngressVisibilityClusterLocal].Len()
 	}
 
-	// CUSTOM LOGIC TO SUPPORT CUSTOM GATEWAYS PER SERVICE.
-	// This is until Knative supports splitting gateways per service as tracked by this PR (https://github.com/knative/serving/pull/4909).
-	customGateway := ia.GetAnnotations()[networking.CustomGatewayAnnotationKey]
-	if customGateway != "" {
-		requiredGatewayCount++
-		// Name format of the custom gateway is either {namespace}/{gateway-name} or {gateway-name}.
-		// If namespace is not specified, it will default to the service namespace.
-		if !strings.Contains(customGateway, "/") {
-			customGateway = VirtualServiceNamespace(ia) + "/" + customGateway
-		}
-		gateways[v1alpha1.IngressVisibilityExternalIP].Insert(customGateway)
-	}
-
 	if requiredGatewayCount > 0 {
 		vss = append(vss, MakeIngressVirtualService(ia, gateways))
 	}


### PR DESCRIPTION
Add Custom Gateway annotation support

## Proposed Changes
* This feature is not expected to be merged into Knative. It is a temporary fix to enable custom gateway support per Knative services. 

* Add a `CustomGatewayAnnotationKey` for specifying the Gateway the VirtualService will use.
This will append to the list of Gateways that Knative creates. Example:
```
networking.knative.dev/customGateway: default/some-gateway
```
* As this is a user-created custom Gateway, users are responsible for maintaining the resource. This means that Knative will **NOT** be responsible for creating, reconciling, or deleting this Gateway. Knative will just append this to the list of Gateways where the VirtualService rule should be applied to.

* The Gateway name format must be of either `{namespace}/{gateway-name}` or `{gateway-name}`, The latter expects the Gateway to be in the same namespace as the service.



